### PR TITLE
Firefox/rc/0.23.0 - #46 Port to FireFox? 

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,12 @@ Since Chrome 90, the JS event that triggers a refresh or a closure has been rewo
 
 ## Changelog
 
+**v0.23.0** Firefox compatibility [#46](https://github.com/sylouuu/chrome-tab-modifier/issues/46)
+
+- Reworked the code to be cross-compatible between Chrome and Firefox
+- Side feature: Changed contextual menu item action because Firefox can't prompt from background. Now the contextual menu action directly open the new rule properties for edition.
+ 
+
 See [releases](https://github.com/sylouuu/chrome-tab-modifier/releases) section.
 
 ## Development

--- a/dist/html/options.html
+++ b/dist/html/options.html
@@ -6,6 +6,7 @@
 
         <title>Tab Modifier</title>
 
+        <link rel="shortcut icon" href="/img/icon_48.png">
         <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/angular_material/1.1.1/angular-material.min.css">
         <link rel="stylesheet" href="/css/options.css">
 

--- a/dist/js/background.js
+++ b/dist/js/background.js
@@ -7,12 +7,17 @@ let options_url = chrome.extension.getURL('html/options.html'), openOptionsPage,
 
 openOptionsPage = function (hash) {
     chrome.tabs.query({ url: options_url }, function (tabs) {
+        let tabOptions = {
+            url: (hash !== undefined) ? options_url + '#' + hash : options_url
+        };
         if (tabs.length > 0) {
-            chrome.tabs.update(tabs[0].id, { active: true, highlighted: true }, function (current_tab) {
+            tabOptions.active = true;
+            // if(isChrome || isOpera)  tabOptions.highighted = true;
+            chrome.tabs.update(tabs[0].id, tabOptions, function (current_tab) {
                 chrome.windows.update(current_tab.windowId, { focused: true });
             });
         } else {
-            chrome.tabs.create({ url: (hash !== undefined) ? options_url + '#' + hash : options_url });
+            chrome.tabs.create(tabOptions);
         }
     });
 };

--- a/dist/js/background.js
+++ b/dist/js/background.js
@@ -38,25 +38,27 @@ chrome.runtime.onMessage.addListener(function (message, sender) {
                 if (current_tab === undefined) {
                     return;
                 }
-                
+
                 let tab, tab_id;
-                
+
                 chrome.tabs.query({}, function (tabs) {
                     for (let i = 0; i < tabs.length; i++) {
                         tab = tabs[i];
-                        
+
                         if (tab.url.indexOf(message.url_fragment) !== -1 && tab.id !== current_tab.id) {
                             tab_id = tab.id;
-                            
+
                             chrome.tabs.executeScript(current_tab.id, {
                                 code: 'window.onbeforeunload = null;'
                             }, function () {
-                                chrome.tabs.remove(current_tab.id);
-                                
                                 chrome.tabs.update(tab_id, {
                                     url: current_tab.url,
-                                    highlighted: true
+                                    active: true
+                                    //if(isChrome || isOpera) highlighted: true
                                 });
+                                chrome.windows.update(tab_id, { focused: true });
+
+                                chrome.tabs.remove(current_tab.id);
                             });
                         }
                     }
@@ -90,7 +92,7 @@ chrome.runtime.onInstalled.addListener(function (details) {
                 if (tab_modifier === undefined || tab_modifier.settings === undefined) {
                     return;
                 }
-                
+
                 if (tab_modifier.settings !== undefined && tab_modifier.settings.enable_new_version_notification === true && details.previousVersion !== chrome.runtime.getManifest().version) {
                     openOptionsPage('update/' + chrome.runtime.getManifest().version);
                 }
@@ -116,7 +118,7 @@ chrome.contextMenus.onClicked.addListener(function (info, tab) {
                     rules: []
                 };
             }
-            
+
             let rule = {
                 name: 'Rule created from right-click (' + tab.url.replace(/(^\w+:|^)\/\//, '').substring(0, 15) + '...)',
                 detection: 'CONTAINS',
@@ -132,9 +134,9 @@ chrome.contextMenus.onClicked.addListener(function (info, tab) {
                     url_matcher: null
                 }
             };
-            
+
             tab_modifier.rules.push(rule);
-            
+
             chrome.storage.local.set({ tab_modifier: tab_modifier });
 
             openOptionsPage('edit-rule/' + tab_modifier.rules.indexOf(rule));

--- a/dist/js/background.js
+++ b/dist/js/background.js
@@ -101,14 +101,12 @@ chrome.runtime.onInstalled.addListener(function (details) {
 
 chrome.contextMenus.create({
     id: 'rename-tab',
-    title: 'Rename Tab',
+    title: 'Create new rule',
     contexts: ['all']
 });
 
 chrome.contextMenus.onClicked.addListener(function (info, tab) {
     if (info.menuItemId === 'rename-tab') {
-        let title = prompt('Enter the new title, a Tab rule will be automatically created for you based on current URL');
-        
         getStorage(function (tab_modifier) {
             if (tab_modifier === undefined) {
                 tab_modifier = {
@@ -124,7 +122,7 @@ chrome.contextMenus.onClicked.addListener(function (info, tab) {
                 detection: 'CONTAINS',
                 url_fragment: tab.url,
                 tab: {
-                    title: title,
+                    title: tab.title,
                     icon: null,
                     pinned: false,
                     protected: false,
@@ -138,8 +136,8 @@ chrome.contextMenus.onClicked.addListener(function (info, tab) {
             tab_modifier.rules.push(rule);
             
             chrome.storage.local.set({ tab_modifier: tab_modifier });
-            
-            chrome.tabs.reload(tab.id);
+
+            openOptionsPage('edit-rule/' + tab_modifier.rules.indexOf(rule));
         });
     }
 });

--- a/dist/js/content.js
+++ b/dist/js/content.js
@@ -5,7 +5,7 @@ chrome.storage.local.get('tab_modifier', function (items) {
         return;
     }
     
-    var tab_modifier = items.tab_modifier, rule = null, processPage;
+    var tab_modifier = items.tab_modifier, rule = null, processPage, MutationObserver = window.MutationObserver || window.WebKitMutationObserver || window.MozMutationObserver;
     
     processPage = function () {
         // Check if a rule is available
@@ -154,7 +154,7 @@ chrome.storage.local.get('tab_modifier', function (items) {
             var el, icon, link;
             
             el = document.querySelectorAll('head link[rel*="icon"]');
-            
+
             // Remove existing favicons
             Array.prototype.forEach.call(el, function (node) {
                 node.parentNode.removeChild(node);
@@ -182,9 +182,9 @@ chrome.storage.local.get('tab_modifier', function (items) {
         }
         
         var title_changed_by_me = false, observer_title;
-        
+
         // Set up a new observer
-        observer_title = new window.WebKitMutationObserver(function (mutations) {
+        observer_title = new MutationObserver(function (mutations) {
             if (title_changed_by_me === true) {
                 title_changed_by_me = false;
             } else {
@@ -219,7 +219,7 @@ chrome.storage.local.get('tab_modifier', function (items) {
             var icon_changed_by_me = false, observer_icon;
             
             // Set up a new observer
-            observer_icon = new window.WebKitMutationObserver(function (mutations) {
+            observer_icon = new MutationObserver(function (mutations) {
                 if (icon_changed_by_me === true) {
                     icon_changed_by_me = false;
                 } else {

--- a/dist/js/content.js
+++ b/dist/js/content.js
@@ -268,7 +268,16 @@ chrome.storage.local.get('tab_modifier', function (items) {
         
         // Protect the tab
         if (rule.tab.protected === true) {
-            w.onbeforeunload = function () {
+            //FF, IE, Safari
+            w.onbeforeunload = function (e) {
+                e = e || window.event;
+
+                // For IE and Firefox
+                if (e) {
+                    e.returnValue = '';
+                }
+
+                // For Safari
                 return '';
             };
         }

--- a/dist/js/options.js
+++ b/dist/js/options.js
@@ -241,7 +241,9 @@ app.controller('TabRulesController', ['$scope', '$routeParams', '$http', '$mdDia
             tab_modifier.sync();
         }
     };
-    
+
+    $scope.$routeParams = $routeParams;
+
     chrome.storage.local.get('tab_modifier', function (items) {
         if (items !== undefined && items.tab_modifier !== undefined) {
             tab_modifier.build(items.tab_modifier);
@@ -250,6 +252,10 @@ app.controller('TabRulesController', ['$scope', '$routeParams', '$http', '$mdDia
         $scope.tab_modifier = tab_modifier;
         
         $scope.$apply();
+
+        if ($scope.$routeParams.event === 'edit-rule') {
+            $scope.showForm(new Event('EditRule'), tab_modifier.rules[$scope.$routeParams.version]);
+        }
     });
     
     // Show modal form

--- a/dist/js/options.js
+++ b/dist/js/options.js
@@ -2,9 +2,9 @@ var app = angular.module('TabModifier', ['ngRoute', 'ngAnimate', 'ngAria', 'ngMa
 
 app.config(['$routeProvider', '$compileProvider', '$mdIconProvider', '$mdThemingProvider', 'AnalyticsProvider', function ($routeProvider, $compileProvider, $mdIconProvider, $mdThemingProvider, AnalyticsProvider) {
     
-    // Allow "chrome-extension" protocol
-    $compileProvider.aHrefSanitizationWhitelist(/^\s*(https?|chrome-extension|file|blob):/);
-    $compileProvider.imgSrcSanitizationWhitelist(/^\s*(https?|chrome-extension|file|blob):|data:image\//);
+    // Allow "chrome-extension" and "moz-extension" protocol
+    $compileProvider.aHrefSanitizationWhitelist(/^\s*(https?|chrome-extension|moz-extension|file|blob):/);
+    $compileProvider.imgSrcSanitizationWhitelist(/^\s*(https?|chrome-extension|moz-extension|file|blob):|data:image\//);
     
     // Load icons list by name
     $mdIconProvider

--- a/dist/js/options.js
+++ b/dist/js/options.js
@@ -227,7 +227,7 @@ app.controller('TabRulesController', ['$scope', '$routeParams', '$http', '$mdDia
     
     // Avoid BC break
     chrome.storage.sync.get('tab_modifier', function (items) {
-        if (items.tab_modifier !== undefined && items.tab_modifier !== null) {
+        if (items !== undefined && items.tab_modifier !== undefined && items.tab_modifier !== null) {
             tab_modifier.build(items.tab_modifier);
             tab_modifier.sync();
         }
@@ -243,7 +243,7 @@ app.controller('TabRulesController', ['$scope', '$routeParams', '$http', '$mdDia
     };
     
     chrome.storage.local.get('tab_modifier', function (items) {
-        if (items.tab_modifier !== undefined) {
+        if (items !== undefined && items.tab_modifier !== undefined) {
             tab_modifier.build(items.tab_modifier);
         }
         

--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -1,4 +1,4 @@
-﻿{
+{
     "manifest_version": 2,
     "name": "Tab Modifier",
     "version": "0.22.0",

--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -18,7 +18,10 @@
 
     "content_security_policy": "script-src 'self' https://ajax.googleapis.com https://www.google-analytics.com; object-src 'self'",
 
-    "options_page": "html/options.html",
+    "options_ui": {
+        "page": "html/options.html",
+        "open_in_tab": true
+    },
 
     "background": {
         "scripts": ["js/background.js"],

--- a/src/html/options.html
+++ b/src/html/options.html
@@ -6,6 +6,7 @@
 
         <title>Tab Modifier</title>
 
+        <link rel="shortcut icon" href="/img/icon_48.png">
         <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/angular_material/1.1.1/angular-material.min.css">
         <link rel="stylesheet" href="/css/options.css">
 

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -7,12 +7,17 @@ let options_url = chrome.extension.getURL('html/options.html'), openOptionsPage,
 
 openOptionsPage = function (hash) {
     chrome.tabs.query({ url: options_url }, function (tabs) {
+        let tabOptions = {
+            url: (hash !== undefined) ? options_url + '#' + hash : options_url
+        };
         if (tabs.length > 0) {
-            chrome.tabs.update(tabs[0].id, { active: true, highlighted: true }, function (current_tab) {
+            tabOptions.active = true;
+            // if(isChrome || isOpera)  tabOptions.highighted = true;
+            chrome.tabs.update(tabs[0].id, tabOptions, function (current_tab) {
                 chrome.windows.update(current_tab.windowId, { focused: true });
             });
         } else {
-            chrome.tabs.create({ url: (hash !== undefined) ? options_url + '#' + hash : options_url });
+            chrome.tabs.create(tabOptions);
         }
     });
 };

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -38,25 +38,27 @@ chrome.runtime.onMessage.addListener(function (message, sender) {
                 if (current_tab === undefined) {
                     return;
                 }
-                
+
                 let tab, tab_id;
-                
+
                 chrome.tabs.query({}, function (tabs) {
                     for (let i = 0; i < tabs.length; i++) {
                         tab = tabs[i];
-                        
+
                         if (tab.url.indexOf(message.url_fragment) !== -1 && tab.id !== current_tab.id) {
                             tab_id = tab.id;
-                            
+
                             chrome.tabs.executeScript(current_tab.id, {
                                 code: 'window.onbeforeunload = null;'
                             }, function () {
-                                chrome.tabs.remove(current_tab.id);
-                                
                                 chrome.tabs.update(tab_id, {
                                     url: current_tab.url,
-                                    highlighted: true
+                                    active: true
+                                    //if(isChrome || isOpera) highlighted: true
                                 });
+                                chrome.windows.update(tab_id, { focused: true });
+
+                                chrome.tabs.remove(current_tab.id);
                             });
                         }
                     }
@@ -90,7 +92,7 @@ chrome.runtime.onInstalled.addListener(function (details) {
                 if (tab_modifier === undefined || tab_modifier.settings === undefined) {
                     return;
                 }
-                
+
                 if (tab_modifier.settings !== undefined && tab_modifier.settings.enable_new_version_notification === true && details.previousVersion !== chrome.runtime.getManifest().version) {
                     openOptionsPage('update/' + chrome.runtime.getManifest().version);
                 }
@@ -116,7 +118,7 @@ chrome.contextMenus.onClicked.addListener(function (info, tab) {
                     rules: []
                 };
             }
-            
+
             let rule = {
                 name: 'Rule created from right-click (' + tab.url.replace(/(^\w+:|^)\/\//, '').substring(0, 15) + '...)',
                 detection: 'CONTAINS',
@@ -132,9 +134,9 @@ chrome.contextMenus.onClicked.addListener(function (info, tab) {
                     url_matcher: null
                 }
             };
-            
+
             tab_modifier.rules.push(rule);
-            
+
             chrome.storage.local.set({ tab_modifier: tab_modifier });
 
             openOptionsPage('edit-rule/' + tab_modifier.rules.indexOf(rule));

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -101,14 +101,12 @@ chrome.runtime.onInstalled.addListener(function (details) {
 
 chrome.contextMenus.create({
     id: 'rename-tab',
-    title: 'Rename Tab',
+    title: 'Create new rule',
     contexts: ['all']
 });
 
 chrome.contextMenus.onClicked.addListener(function (info, tab) {
     if (info.menuItemId === 'rename-tab') {
-        let title = prompt('Enter the new title, a Tab rule will be automatically created for you based on current URL');
-        
         getStorage(function (tab_modifier) {
             if (tab_modifier === undefined) {
                 tab_modifier = {
@@ -124,7 +122,7 @@ chrome.contextMenus.onClicked.addListener(function (info, tab) {
                 detection: 'CONTAINS',
                 url_fragment: tab.url,
                 tab: {
-                    title: title,
+                    title: tab.title,
                     icon: null,
                     pinned: false,
                     protected: false,
@@ -138,8 +136,8 @@ chrome.contextMenus.onClicked.addListener(function (info, tab) {
             tab_modifier.rules.push(rule);
             
             chrome.storage.local.set({ tab_modifier: tab_modifier });
-            
-            chrome.tabs.reload(tab.id);
+
+            openOptionsPage('edit-rule/' + tab_modifier.rules.indexOf(rule));
         });
     }
 });

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -5,7 +5,7 @@ chrome.storage.local.get('tab_modifier', function (items) {
         return;
     }
     
-    var tab_modifier = items.tab_modifier, rule = null, processPage;
+    var tab_modifier = items.tab_modifier, rule = null, processPage, MutationObserver = window.MutationObserver || window.WebKitMutationObserver || window.MozMutationObserver;
     
     processPage = function () {
         // Check if a rule is available
@@ -154,7 +154,7 @@ chrome.storage.local.get('tab_modifier', function (items) {
             var el, icon, link;
             
             el = document.querySelectorAll('head link[rel*="icon"]');
-            
+
             // Remove existing favicons
             Array.prototype.forEach.call(el, function (node) {
                 node.parentNode.removeChild(node);
@@ -182,9 +182,9 @@ chrome.storage.local.get('tab_modifier', function (items) {
         }
         
         var title_changed_by_me = false, observer_title;
-        
+
         // Set up a new observer
-        observer_title = new window.WebKitMutationObserver(function (mutations) {
+        observer_title = new MutationObserver(function (mutations) {
             if (title_changed_by_me === true) {
                 title_changed_by_me = false;
             } else {
@@ -219,7 +219,7 @@ chrome.storage.local.get('tab_modifier', function (items) {
             var icon_changed_by_me = false, observer_icon;
             
             // Set up a new observer
-            observer_icon = new window.WebKitMutationObserver(function (mutations) {
+            observer_icon = new MutationObserver(function (mutations) {
                 if (icon_changed_by_me === true) {
                     icon_changed_by_me = false;
                 } else {

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -268,7 +268,16 @@ chrome.storage.local.get('tab_modifier', function (items) {
         
         // Protect the tab
         if (rule.tab.protected === true) {
-            w.onbeforeunload = function () {
+            //FF, IE, Safari
+            w.onbeforeunload = function (e) {
+                e = e || window.event;
+
+                // For IE and Firefox
+                if (e) {
+                    e.returnValue = '';
+                }
+
+                // For Safari
                 return '';
             };
         }

--- a/src/js/options/app.js
+++ b/src/js/options/app.js
@@ -2,9 +2,9 @@ var app = angular.module('TabModifier', ['ngRoute', 'ngAnimate', 'ngAria', 'ngMa
 
 app.config(['$routeProvider', '$compileProvider', '$mdIconProvider', '$mdThemingProvider', 'AnalyticsProvider', function ($routeProvider, $compileProvider, $mdIconProvider, $mdThemingProvider, AnalyticsProvider) {
     
-    // Allow "chrome-extension" protocol
-    $compileProvider.aHrefSanitizationWhitelist(/^\s*(https?|chrome-extension|file|blob):/);
-    $compileProvider.imgSrcSanitizationWhitelist(/^\s*(https?|chrome-extension|file|blob):|data:image\//);
+    // Allow "chrome-extension" and "moz-extension" protocol
+    $compileProvider.aHrefSanitizationWhitelist(/^\s*(https?|chrome-extension|moz-extension|file|blob):/);
+    $compileProvider.imgSrcSanitizationWhitelist(/^\s*(https?|chrome-extension|moz-extension|file|blob):|data:image\//);
     
     // Load icons list by name
     $mdIconProvider

--- a/src/js/options/controllers/tab_rules.controller.js
+++ b/src/js/options/controllers/tab_rules.controller.js
@@ -23,7 +23,9 @@ app.controller('TabRulesController', ['$scope', '$routeParams', '$http', '$mdDia
             tab_modifier.sync();
         }
     };
-    
+
+    $scope.$routeParams = $routeParams;
+
     chrome.storage.local.get('tab_modifier', function (items) {
         if (items !== undefined && items.tab_modifier !== undefined) {
             tab_modifier.build(items.tab_modifier);
@@ -32,6 +34,10 @@ app.controller('TabRulesController', ['$scope', '$routeParams', '$http', '$mdDia
         $scope.tab_modifier = tab_modifier;
         
         $scope.$apply();
+
+        if ($scope.$routeParams.event === 'edit-rule') {
+            $scope.showForm(new Event('EditRule'), tab_modifier.rules[$scope.$routeParams.version]);
+        }
     });
     
     // Show modal form

--- a/src/js/options/controllers/tab_rules.controller.js
+++ b/src/js/options/controllers/tab_rules.controller.js
@@ -9,7 +9,7 @@ app.controller('TabRulesController', ['$scope', '$routeParams', '$http', '$mdDia
     
     // Avoid BC break
     chrome.storage.sync.get('tab_modifier', function (items) {
-        if (items.tab_modifier !== undefined && items.tab_modifier !== null) {
+        if (items !== undefined && items.tab_modifier !== undefined && items.tab_modifier !== null) {
             tab_modifier.build(items.tab_modifier);
             tab_modifier.sync();
         }
@@ -25,7 +25,7 @@ app.controller('TabRulesController', ['$scope', '$routeParams', '$http', '$mdDia
     };
     
     chrome.storage.local.get('tab_modifier', function (items) {
-        if (items.tab_modifier !== undefined) {
+        if (items !== undefined && items.tab_modifier !== undefined) {
             tab_modifier.build(items.tab_modifier);
         }
         


### PR DESCRIPTION
Hi @sylouuu 

Here is a release candidate for a Firefox compatible version of this module.
As Firefox has done its transition to WebExtensions, it is now mostly compatible with chrome extensions. (They even declared the chrome.* namespace to make the transition easier)

I made the needed adjustment and the extension is now fully functional on both browser.
The only functionality that I had to change was the contextual menu shortcut and I tried to improve it on the way.

Mitigation:
 - Only tested on last browsers version (Chrome 64 & Firefox 58)
 - No idea of the full process of publishing an extension on Firefox. I followed the [guideline](https://developer.mozilla.org/fr/Add-ons/Distribution) to generate a [signed version](https://github.com/clfer/chrome-tab-modifier/raw/de52a77d5befc59f0ef23d6c7969f7f67590caab/dist/web-ext-artifacts/tab_modifier-0.21.0.xpi) but I don't really want to take all the credit and publish it under my name. How do you want to proceed?

Waiting for your feedback 

Have a good night