### PR TITLE
Rule application order: Update help.html

### DIFF
--- a/src/html/help.html
+++ b/src/html/help.html
@@ -124,7 +124,7 @@
 
             <p>After creating or editing a rule, refresh the tab(s) to apply the changes.</p>
 
-            <p>The order of your rules is important, if an URL triggers more than one rule, the first one will be applied. You can reorder your rules anyway.</p>
+            <p>The order of your rules is important, if an URL triggers more than one rule, the last one will be applied. You can reorder your rules anyway.</p>
 
             <p>Some interesting tab rules are listed <a href="https://github.com/sylouuu/chrome-tab-modifier#examples" target="_blank">here</a> for inspiration purposes.</p>
 


### PR DESCRIPTION
In my experience today, it appears that the lowest/bottom-most rule is the one that's applied. Perhaps they are all applied, in-order, and the last ones can overwrite preceding rules?