### PR TITLE
feat - modify background.js and manifest.json to add shortcut for ren…

### DIFF
--- a/dist/js/background.js
+++ b/dist/js/background.js
@@ -23,6 +23,43 @@ getStorage = function (callback) {
     });
 };
 
+function renameTab(tab) {
+    let title = prompt('Enter the new title, a Tab rule will be automatically created for you based on current URL');
+
+    getStorage(function (tab_modifier) {
+        if (tab_modifier === undefined) {
+            tab_modifier = {
+                settings: {
+                    enable_new_version_notification: false
+                },
+                rules: []
+            };
+        }
+
+        let rule = {
+            name: 'Rule created from right-click (' + tab.url.replace(/(^\w+:|^)\/\//, '').substring(0, 15) + '...)',
+            detection: 'CONTAINS',
+            url_fragment: tab.url,
+            tab: {
+                title: title,
+                icon: null,
+                pinned: false,
+                protected: false,
+                unique: false,
+                muted: false,
+                title_matcher: null,
+                url_matcher: null
+            }
+        };
+
+        tab_modifier.rules.push(rule);
+
+        chrome.storage.local.set({ tab_modifier: tab_modifier });
+
+        chrome.tabs.reload(tab.id);
+    });
+}
+
 // --------------------------------------------------------------------------------------------------------
 // Events
 
@@ -33,21 +70,21 @@ chrome.runtime.onMessage.addListener(function (message, sender) {
                 if (current_tab === undefined) {
                     return;
                 }
-                
+
                 let tab, tab_id;
-                
+
                 chrome.tabs.query({}, function (tabs) {
                     for (let i = 0; i < tabs.length; i++) {
                         tab = tabs[i];
-                        
+
                         if (tab.url.indexOf(message.url_fragment) !== -1 && tab.id !== current_tab.id) {
                             tab_id = tab.id;
-                            
+
                             chrome.tabs.executeScript(current_tab.id, {
                                 code: 'window.onbeforeunload = null;'
                             }, function () {
                                 chrome.tabs.remove(current_tab.id);
-                                
+
                                 chrome.tabs.update(tab_id, {
                                     url: current_tab.url,
                                     highlighted: true
@@ -85,7 +122,7 @@ chrome.runtime.onInstalled.addListener(function (details) {
                 if (tab_modifier === undefined || tab_modifier.settings === undefined) {
                     return;
                 }
-                
+
                 if (tab_modifier.settings !== undefined && tab_modifier.settings.enable_new_version_notification === true && details.previousVersion !== chrome.runtime.getManifest().version) {
                     openOptionsPage('update/' + chrome.runtime.getManifest().version);
                 }
@@ -102,39 +139,16 @@ chrome.contextMenus.create({
 
 chrome.contextMenus.onClicked.addListener(function (info, tab) {
     if (info.menuItemId === 'rename-tab') {
-        let title = prompt('Enter the new title, a Tab rule will be automatically created for you based on current URL');
-        
-        getStorage(function (tab_modifier) {
-            if (tab_modifier === undefined) {
-                tab_modifier = {
-                    settings: {
-                        enable_new_version_notification: false
-                    },
-                    rules: []
-                };
+        renameTab(tab);
+    }
+});
+
+chrome.commands.onCommand.addListener(function (command) {
+    if (command === 'rename-tab') {
+        chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
+            if (tabs.length > 0) {
+                renameTab(tabs[0]);
             }
-            
-            let rule = {
-                name: 'Rule created from right-click (' + tab.url.replace(/(^\w+:|^)\/\//, '').substring(0, 15) + '...)',
-                detection: 'CONTAINS',
-                url_fragment: tab.url,
-                tab: {
-                    title: title,
-                    icon: null,
-                    pinned: false,
-                    protected: false,
-                    unique: false,
-                    muted: false,
-                    title_matcher: null,
-                    url_matcher: null
-                }
-            };
-            
-            tab_modifier.rules.push(rule);
-            
-            chrome.storage.local.set({ tab_modifier: tab_modifier });
-            
-            chrome.tabs.reload(tab.id);
         });
     }
 });

--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -42,5 +42,13 @@
         "tabs",
         "storage",
         "contextMenus"
-    ]
+    ],
+    "commands": {
+      "rename-tab": {
+        "suggested_key": {
+          "default": "Ctrl+Shift+Y"
+        },
+        "description": "Rename the current tab"
+      }
+    }
 }


### PR DESCRIPTION
### Description

This pull request addresses the feature enhancement to add a shortcut for the rename tab functionality. The changes have been tested locally and are confirmed to be working.

### Changes Made

- Directly edited files under the `dist/` directory.
- Abstract out the rename tab code in `background.json`
- Updated `manifest.json` to reflect the necessary changes.

### Notes

I encountered issues running Gulp after modifying files under the `src/` directory, which led me to directly edit the `dist/` files. Additionally, I am unsure of the correct process to edit `manifest.json` from the `src/` directory.

### Request for Feedback

I would appreciate any comments or guidelines!

Thank you for your assistance!
