### PR TITLE
fix: protected & unique rule

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -44,7 +44,8 @@
     "tabs",
     "tabGroups",
     "storage",
-    "contextMenus"
+    "contextMenus",
+    "scripting"
   ],
   "host_permissions": [
     "http://*/*",

--- a/src/components/options/center/sections/HelpPane.vue
+++ b/src/components/options/center/sections/HelpPane.vue
@@ -98,10 +98,12 @@
 				<p>This action will pin the tab.</p>
 
 				<h3 class="font-bold">Protected</h3>
-				<p>This action will ask you before closing the tab.</p>
+				<p>This action will ask you before refreshing or closing the tab.</p>
 				<p>
-					Note: the confirm box will be triggered if you (or the website itself) refresh the tab, as
-					the extension can't differentiate closure and refresh.
+					Note: Require sticky activation for the dialog to be displayed. In other words, the
+					browser will only show the dialog box if the frame or any embedded frame receives a user
+					gesture or user interaction. If you have never interacted with the page, the dialog will
+					not be displayed.
 				</p>
 
 				<h3 class="font-bold">Unique</h3>

--- a/src/content.js
+++ b/src/content.js
@@ -188,9 +188,10 @@ export async function applyRule(ruleParam) {
 		});
 	}
 
-	// Protection (disable beforeunload event) and unique tab handling
 	if (rule.tab.protected) {
-		window.onbeforeunload = () => '';
+		await chrome.runtime.sendMessage({
+			action: 'setProtected',
+		});
 	}
 
 	if (rule.tab.unique) {

--- a/src/content.test.js
+++ b/src/content.test.js
@@ -246,7 +246,9 @@ describe('Content', () => {
 			};
 			_getRuleFromUrl.mockResolvedValue(rule);
 			await applyRule(rule);
-			expect(window.onbeforeunload).toBeInstanceOf(Function);
+			expect(global.chrome.runtime.sendMessage).toHaveBeenCalledWith({
+				action: 'setProtected',
+			});
 		});
 	});
 });


### PR DESCRIPTION
🚨 The protected rule will not work as before due to browser restrictions.

https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event#usage_notes


> Require sticky activation for the dialog to be displayed. In other words, the browser will only show the dialog box if the frame or any embedded frame receives a user gesture or user interaction. If the user has never interacted with the page, then there is no user data to save, so no legitimate use case for the dialog.

