### PR TITLE
fix: group name is not set after reordering a tab

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -236,7 +236,7 @@ async function applyGroupRuleToTab(
 // 	}
 // }
 
-let handleTabGroupsMaxRetries = 20;
+let handleTabGroupsMaxRetries = 600;
 async function handleTabGroups(
 	groups: chrome.tabGroups.TabGroup[],
 	tab: chrome.tabs.Tab,
@@ -258,7 +258,7 @@ async function handleTabGroups(
 					handleTabGroupsMaxRetries--;
 					return;
 				} else {
-					handleTabGroupsMaxRetries = 20;
+					handleTabGroupsMaxRetries = 600;
 					updateTabGroup(groupId, tmGroup);
 				}
 			});
@@ -268,7 +268,7 @@ async function handleTabGroups(
 	}
 }
 
-let createAndSetupGroupMaxRetries = 20;
+let createAndSetupGroupMaxRetries = 600;
 async function createAndSetupGroup(tabIds: number[], tmGroup: Group) {
 	const execute = () => {
 		chrome.tabs.group({ tabIds: tabIds }, (groupId: number) => {
@@ -277,7 +277,7 @@ async function createAndSetupGroup(tabIds: number[], tmGroup: Group) {
 				createAndSetupGroupMaxRetries--;
 				return;
 			} else {
-				createAndSetupGroupMaxRetries = 20;
+				createAndSetupGroupMaxRetries = 600;
 				updateTabGroup(groupId, tmGroup);
 			}
 		});
@@ -286,7 +286,7 @@ async function createAndSetupGroup(tabIds: number[], tmGroup: Group) {
 	execute();
 }
 
-let updateTabGroupMaxRetries = 20;
+let updateTabGroupMaxRetries = 600;
 async function updateTabGroup(groupId: number, tmGroup: Group) {
 	if (!groupId) return;
 


### PR DESCRIPTION
The `onMoved` event triggers when a tab is moved, but the user might still be holding the tab (dragging), which generates this error:

```
Unchecked runtime.lastError: Tabs cannot be edited right now (user may be dragging a tab).
```

To work around this, I retry the call with the Chrome API every 100ms as long as `runtime.lastError` is set.

I have also added a maximum of 600 retries, equivalent to a maximum wait time of 1 minute. Therefore, if a user holds a tab for more than a minute, the rule will not apply.