### PR TITLE
 fix: update Data URI generation link in help documentation

### DIFF
--- a/src/components/options/center/sections/HelpPane.vue
+++ b/src/components/options/center/sections/HelpPane.vue
@@ -83,7 +83,7 @@
 				<ul class="list-disc ml-3">
 					<li>upload your icon somewhere like imgur.com and paste the direct link</li>
 					<li>
-						go to duri.me and drag & drop your icon, then click on "Copy as DataURI" and paste it.
+						go to <a href="https://ezgif.com/image-to-datauri" target="_blank" class="link">ezgif.com</a> and upload your icon, then copy the generated Data URI and paste it.
 						This is your icon transformed in the Data URI format
 					</li>
 				</ul>


### PR DESCRIPTION
 ## Summary
  Update the help documentation to replace the obsolete duri.me reference with the working ezgif.com service for Data URI generation.

  ## Changes
  - Replace `duri.me` with `ezgif.com/image-to-datauri` in HelpPane.vue
  - Add clickable link with target="_blank"
  - Update instructions to match the actual ezgif.com workflow

  ## Background
  The previously referenced duri.me website no longer provides Data URI generation functionality, leaving users without proper guidance for creating Data URI icons.

  Fixes #472